### PR TITLE
Add Makefiles and user config templates for apt, homebrew, npm, pipx, and yarn

### DIFF
--- a/apt/Makefile
+++ b/apt/Makefile
@@ -1,0 +1,25 @@
+XDG_CONFIG_HOME ?= ${HOME}/.config
+
+PKG_NAME=apt
+CONFIG_DIR=${XDG_CONFIG_HOME}/$(PKG_NAME)
+OSTYPE=$(shell uname)
+
+.ONESHELL:
+
+config.$(PKG_NAME): install.$(PKG_NAME)
+	$(H)echo "-- $(PKG_NAME): setup config --"
+	$(H)echo "APT uses system-level config under /etc/apt; keep user notes in ${CONFIG_DIR}."
+
+install.$(PKG_NAME):
+	$(H)echo "-- $(PKG_NAME): check package manager --"
+	$(H)if [[ "$(OSTYPE)" != "Linux" ]]; then
+		echo "apt is only available on Linux"
+		exit 0
+	fi
+	$(H)sudo apt-get update
+
+remove.$(PKG_NAME):
+	$(H)echo "-- $(PKG_NAME): remove config --"
+	$(H)rm -rf "${CONFIG_DIR}"
+
+.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)

--- a/apt/README.md
+++ b/apt/README.md
@@ -1,0 +1,4 @@
+# apt notes
+
+`apt` configuration is system-level (`/etc/apt`).
+This folder keeps user-level notes/scripts that live in dotfiles.

--- a/homebrew/Makefile
+++ b/homebrew/Makefile
@@ -1,0 +1,27 @@
+XDG_CONFIG_HOME ?= ${HOME}/.config
+
+PKG_NAME=homebrew
+CONFIG_DIR=${XDG_CONFIG_HOME}/$(PKG_NAME)
+BREW=$(shell command -v brew)
+
+.ONESHELL:
+
+config.$(PKG_NAME): install.$(PKG_NAME)
+	$(H)echo "-- $(PKG_NAME): setup config --"
+	$(H)if [[ -f "${CONFIG_DIR}/brew.env" ]]; then
+		grep -q 'homebrew/brew.env' "${HOME}/.bashrc" || echo '[[ -f "${CONFIG_DIR}/brew.env" ]] && source "${CONFIG_DIR}/brew.env"' >> "${HOME}/.bashrc"
+	fi
+
+install.$(PKG_NAME):
+	$(H)echo "-- $(PKG_NAME): install package manager --"
+	$(H)if [[ -z "$(BREW)" ]]; then
+		/bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+	else
+		echo "brew already installed: $(BREW)"
+	fi
+
+remove.$(PKG_NAME):
+	$(H)echo "-- $(PKG_NAME): remove config --"
+	$(H)rm -rf "${CONFIG_DIR}"
+
+.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)

--- a/homebrew/brew.env
+++ b/homebrew/brew.env
@@ -1,14 +1,14 @@
-# If set, do not automatically update before running some commands, e.g. brew
-# install, brew upgrade and brew tap. Preferably, run this less often by
-# setting HOMEBREW_AUTO_UPDATE_SECS to a value higher than the default. Note
-# that setting this and e.g. tapping new taps may result in a broken
-# configuration. Please ensure you always run brew update before reporting any
-# issues.
-export HOMEBREW_NO_AUTO_UPDATE=1
+# Homebrew environment hook for ~/.config/homebrew
+# shellcheck shell=bash
 
-# If set, do not check for broken linkage of dependents or outdated dependents
-# after installing, upgrading or reinstalling formulae. This will result in
-# fewer  dependents (and their dependencies) being upgraded or reinstalled but
-# may result in more breakage from running brew install formula or brew upgrade
-# formula.
+if [[ -x /opt/homebrew/bin/brew ]]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"      # macOS (Apple Silicon)
+elif [[ -x /usr/local/bin/brew ]]; then
+  eval "$(/usr/local/bin/brew shellenv)"         # macOS (Intel)
+elif [[ -x /home/linuxbrew/.linuxbrew/bin/brew ]]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"  # Linuxbrew
+fi
+
+# Keep brew quieter in automation.
+export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1

--- a/npm/Makefile
+++ b/npm/Makefile
@@ -1,0 +1,29 @@
+XDG_CONFIG_HOME ?= ${HOME}/.config
+
+PKG_NAME=npm
+CONFIG_DIR=${XDG_CONFIG_HOME}/$(PKG_NAME)
+OSTYPE=$(shell uname)
+
+.ONESHELL:
+
+config.$(PKG_NAME): install.$(PKG_NAME)
+	$(H)echo "-- $(PKG_NAME): setup config --"
+	$(H)ln -snf "${CONFIG_DIR}/npmrc" "${HOME}/.npmrc"
+
+install.$(PKG_NAME):
+	$(H)echo "-- $(PKG_NAME): install package manager --"
+	$(H)if [[ "$(OSTYPE)" == "Darwin" ]]; then
+		brew install node
+	elif [[ "$(OSTYPE)" == "Linux" ]]; then
+		sudo apt-get update
+		sudo apt-get install -y nodejs npm
+	else
+		echo "Unsupported OS: $(OSTYPE)"
+	fi
+
+remove.$(PKG_NAME):
+	$(H)echo "-- $(PKG_NAME): remove config --"
+	$(H)rm -f "${HOME}/.npmrc"
+	$(H)rm -rf "${CONFIG_DIR}"
+
+.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)

--- a/npm/npmrc
+++ b/npm/npmrc
@@ -1,0 +1,4 @@
+cache=${HOME}/.cache/npm
+prefix=${HOME}/.local
+fund=false
+audit=false

--- a/pipx/Makefile
+++ b/pipx/Makefile
@@ -1,0 +1,28 @@
+XDG_CONFIG_HOME ?= ${HOME}/.config
+
+PKG_NAME=pipx
+CONFIG_DIR=${XDG_CONFIG_HOME}/$(PKG_NAME)
+OSTYPE=$(shell uname)
+
+.ONESHELL:
+
+config.$(PKG_NAME): install.$(PKG_NAME)
+	$(H)echo "-- $(PKG_NAME): setup config --"
+	$(H)pipx ensurepath
+
+install.$(PKG_NAME):
+	$(H)echo "-- $(PKG_NAME): install package manager --"
+	$(H)if [[ "$(OSTYPE)" == "Darwin" ]]; then
+		brew install pipx
+	elif [[ "$(OSTYPE)" == "Linux" ]]; then
+		sudo apt-get update
+		sudo apt-get install -y pipx || sudo apt-get install -y python3-pipx
+	else
+		echo "Unsupported OS: $(OSTYPE)"
+	fi
+
+remove.$(PKG_NAME):
+	$(H)echo "-- $(PKG_NAME): remove config --"
+	$(H)rm -rf "${CONFIG_DIR}"
+
+.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)

--- a/pipx/pipx.env
+++ b/pipx/pipx.env
@@ -1,0 +1,3 @@
+# Optional pipx environment file
+export PIPX_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/pipx"
+export PIPX_BIN_DIR="${HOME}/.local/bin"

--- a/yarn/Makefile
+++ b/yarn/Makefile
@@ -1,0 +1,32 @@
+XDG_CONFIG_HOME ?= ${HOME}/.config
+
+PKG_NAME=yarn
+CONFIG_DIR=${XDG_CONFIG_HOME}/$(PKG_NAME)
+
+.ONESHELL:
+
+config.$(PKG_NAME): install.$(PKG_NAME)
+	$(H)echo "-- $(PKG_NAME): setup config --"
+	$(H)ln -snf "${CONFIG_DIR}/yarnrc.yml" "${HOME}/.yarnrc.yml"
+
+install.$(PKG_NAME):
+	$(H)echo "-- $(PKG_NAME): install package manager --"
+	$(H)if ! command -v node >/dev/null 2>&1; then
+		echo "node is required; run make npm first"
+		exit 1
+	fi
+	$(H)if command -v corepack >/dev/null 2>&1; then
+		corepack enable
+		corepack prepare yarn@stable --activate
+	else
+		npm install -g corepack
+		corepack enable
+		corepack prepare yarn@stable --activate
+	fi
+
+remove.$(PKG_NAME):
+	$(H)echo "-- $(PKG_NAME): remove config --"
+	$(H)rm -f "${HOME}/.yarnrc.yml"
+	$(H)rm -rf "${CONFIG_DIR}"
+
+.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)

--- a/yarn/yarnrc.yml
+++ b/yarn/yarnrc.yml
@@ -1,0 +1,4 @@
+# Yarn config (v2+)
+enableGlobalCache: true
+globalFolder: "${HOME}/.local/share/yarn/global"
+cacheFolder: "${HOME}/.cache/yarn"


### PR DESCRIPTION
### Motivation

- Provide per-package-manager Makefile targets to install, configure, and remove user-level configuration for common package managers.
- Centralize user config under `XDG_CONFIG_HOME` and provide small environment/header files for shell integration and reproducible dotfiles.
- Offer cross-platform install flows (macOS vs Linux) and convenience links for user dotfiles like `~/.npmrc` and `~/.yarnrc.yml`.

### Description

- Added `Makefile` targets for `apt`, `homebrew`, `npm`, `pipx`, and `yarn` that expose `config.<pkg>`, `install.<pkg>`, and `remove.<pkg>` recipes and honor `XDG_CONFIG_HOME` and `HOME`.
- Added user config templates: `homebrew/brew.env` (sets `brew shellenv` and disables auto-updates), `npm/npmrc`, `pipx/pipx.env`, `yarn/yarnrc.yml`, and an `apt/README.md` explaining system-level config.
- Implemented OS detection and install logic: `brew` installer for macOS, `apt-get` for Linux where appropriate, `npm`/`node` dependency checks for `yarn`, and `pipx ensurepath` usage in `pipx` config step.
- Each `Makefile` includes safe `remove` targets that delete the per-package `CONFIG_DIR` and any linked dotfiles, and declares the targets as `.PHONY`.

### Testing

- No automated tests were run for these additions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d148de5e7c832984909d997d096115)