### PR TITLE
Support top-level `make install|config|uninstall [pkg...]` syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ SHELL?=bash
 H?=@
 
 LIST:=$(shell ls -d -- */ | sed 's:/::' | grep -v '^sys\|^apps\|^bin')
+ACTION_TARGETS:=install uninstall config
+PKGS:=$(filter-out $(ACTION_TARGETS),$(MAKECMDGOALS))
 
 -include $(ROOT)/apps/Makefile
 
@@ -21,6 +23,9 @@ all: $(LIST)
 # dotfile: $(DOTFILE)
 
 $(LIST):
+	$(H)if [ -n "$(filter $(ACTION_TARGETS),$(MAKECMDGOALS))" ]; then
+		exit 0
+	fi
 	$(H)$(eval SRC_DIR:=$(ROOT)/$@)
 	$(H)$(eval DST_DIR:=$(CONF_HOME)/$@)
 
@@ -46,8 +51,32 @@ bin:
 	fi
 	$(H)echo "Remove Configuration: $(NAME)"
 
-%.install:
+install:
+	$(H)if [ -z "$(strip $(PKGS))" ]; then
+		echo "Usage: make install [pkg1] [pkg2] ..."
+		exit 1
+	fi
+	$(H)$(MAKE) --no-print-directory $(PKGS)
 
-%.uninstall:
+config:
+	$(H)if [ -z "$(strip $(PKGS))" ]; then
+		echo "Usage: make config [pkg1] [pkg2] ..."
+		exit 1
+	fi
+	$(H)$(MAKE) --no-print-directory $(PKGS)
 
-.PHONY: all %.remove %.install %.uninstall $(LIST) $(ALIAS) bin
+uninstall:
+	$(H)if [ -z "$(strip $(PKGS))" ]; then
+		echo "Usage: make uninstall [pkg1] [pkg2] ..."
+		exit 1
+	fi
+	$(H)for pkg in $(PKGS); do
+		H=$(H) $(MAKE) --no-print-directory $$pkg.remove || exit $$?
+	done
+
+ifneq (,$(filter $(ACTION_TARGETS),$(MAKECMDGOALS)))
+%:
+	@:
+endif
+
+.PHONY: all %.remove install uninstall config $(LIST) $(ALIAS) bin

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -24,10 +24,16 @@ UNDER_CONFDIR_SUBDIR:=
 #
 # Add the configuration file name to the targets
 $(UNDER_HOME):
+	$(H)if [ -n "$(filter $(ACTION_TARGETS),$(MAKECMDGOALS))" ]; then
+		exit 0
+	fi
 	$(H)cp -rvf $(DOTFILE_HOMEDIR)/$@ $(HOME)/.$@
 	$(H)printf -- "-- completed: $@ --\n"
 
 $(UNDER_CONFDIR):
+	$(H)if [ -n "$(filter $(ACTION_TARGETS),$(MAKECMDGOALS))" ]; then
+		exit 0
+	fi
 	$(H)cp -rvf $(DOTFILE_CONFDIR)/$@ $(CONF_HOME)/$@
 	$(H)printf -- "-- completed: $@ --\n"
 


### PR DESCRIPTION
### Motivation

- Replace the old per-package invocation style (`make <pkg>.remove` / `make <pkg>`) with clear top-level action commands to simplify usage. 
- Allow invoking actions for multiple packages in one command such as `make install bash tig`.
- Prevent double execution of package targets when using action-mode commands.

### Description

- Added `ACTION_TARGETS` and `PKGS` parsing in `Makefile` to extract the action (`install`, `config`, `uninstall`) and the list of package goals from `MAKECMDGOALS`. 
- Implemented top-level `install`, `config`, and `uninstall` targets in `Makefile` that validate arguments and dispatch to package targets, where `uninstall` routes each package to the existing `<pkg>.remove` rule. 
- Added action-mode guards to the root package rule in `Makefile` and to `$(UNDER_HOME)` / `$(UNDER_CONFDIR)` rules in `apps/Makefile` to skip normal package copy behavior when an action target is invoked. 
- Introduced a conditional no-op fallback (`%:`) during action-mode to absorb extra goals and adjusted `.PHONY` accordingly.

### Testing

- Ran dry-run installs with `make -n install bash` and observed expected dispatch to the `bash` package target (success). 
- Ran dry-run configs with `make -n config bash tig` and observed expected dispatch to both `bash` and `tig` targets (success). 
- Ran dry-run uninstall with `make -n uninstall bash` and observed it invoke `bash.remove` behavior (success). 
- Validated usage-path error behavior with `make -n install || true`, `make -n config || true`, and `make -n uninstall || true` and confirmed each prints usage and returns non-zero as expected (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d157944eac8329b025cca18645b9b9)