### PR TITLE
Standardize package Makefiles with unified install/config/uninstall flow and add package entries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,29 +41,36 @@ bin:
 	$(H)mkdir -p $(XDG_LOCAL_BIN)
 	$(H)cp -rvf $(ROOT)/bin/* $(XDG_LOCAL_BIN)
 
-%.remove:
-	$(H)$(eval NAME:=$(strip $(subst .remove,,$@)))
-	$(H)if [ -d "$(CONF_HOME)/$(NAME)" ]; then
-		rm -rvf $(CONF_HOME)/$(NAME)
-	elif [ -e "$(CONF_HOME)/dotfile/$(NAME)" ]; then
-		rm -rvf $(CONF_HOME)/dotfile/$(NAME)
-		rm -rvf ~/.$(NAME)
-	fi
-	$(H)echo "Remove Configuration: $(NAME)"
-
 install:
 	$(H)if [ -z "$(strip $(PKGS))" ]; then
 		echo "Usage: make install [pkg1] [pkg2] ..."
 		exit 1
 	fi
-	$(H)$(MAKE) --no-print-directory $(PKGS)
+	$(H)for pkg in $(PKGS); do
+		SRC_DIR="$(ROOT)/$$pkg"
+		DST_DIR="$(CONF_HOME)/$$pkg"
+		cp -rvf $$SRC_DIR $(CONF_HOME)/
+		if [ -e "$$DST_DIR/Makefile" ]; then
+			H=$(H) $(MAKE) --no-print-directory -C "$$DST_DIR" install || exit $$?
+		elif [ -e "$$DST_DIR/install.sh" ]; then
+			bash $$DST_DIR/install.sh
+		fi
+		printf -- "-- completed: $$pkg --\n\n"
+	done
 
 config:
 	$(H)if [ -z "$(strip $(PKGS))" ]; then
 		echo "Usage: make config [pkg1] [pkg2] ..."
 		exit 1
 	fi
-	$(H)$(MAKE) --no-print-directory $(PKGS)
+	$(H)for pkg in $(PKGS); do
+		DST_DIR="$(CONF_HOME)/$$pkg"
+		if [ -e "$$DST_DIR/Makefile" ]; then
+			H=$(H) $(MAKE) --no-print-directory -C "$$DST_DIR" config || exit $$?
+		elif [ -e "$$DST_DIR/configure.sh" ]; then
+			bash $$DST_DIR/configure.sh
+		fi
+	done
 
 uninstall:
 	$(H)if [ -z "$(strip $(PKGS))" ]; then
@@ -71,7 +78,23 @@ uninstall:
 		exit 1
 	fi
 	$(H)for pkg in $(PKGS); do
-		H=$(H) $(MAKE) --no-print-directory $$pkg.remove || exit $$?
+		if [ -d "$(CONF_HOME)/$$pkg" ]; then
+			if [ -f "$(CONF_HOME)/$$pkg/Makefile" ]; then
+				H=$(H) $(MAKE) --no-print-directory -C "$(CONF_HOME)/$$pkg" uninstall || true
+			elif [ -f "$(CONF_HOME)/$$pkg/uninstall.sh" ]; then
+				bash $(CONF_HOME)/$$pkg/uninstall.sh || true
+			fi
+			rm -rvf $(CONF_HOME)/$$pkg
+		elif [ -e "$(CONF_HOME)/dotfile/$$pkg" ]; then
+			if [ -f "$(CONF_HOME)/dotfile/$$pkg/Makefile" ]; then
+				H=$(H) $(MAKE) --no-print-directory -C "$(CONF_HOME)/dotfile/$$pkg" uninstall || true
+			elif [ -f "$(CONF_HOME)/dotfile/$$pkg/uninstall.sh" ]; then
+				bash $(CONF_HOME)/dotfile/$$pkg/uninstall.sh || true
+			fi
+			rm -rvf $(CONF_HOME)/dotfile/$$pkg
+			rm -rvf ~/.$$pkg
+		fi
+		echo "Remove Configuration: $$pkg"
 	done
 
 ifneq (,$(filter $(ACTION_TARGETS),$(MAKECMDGOALS)))
@@ -79,4 +102,4 @@ ifneq (,$(filter $(ACTION_TARGETS),$(MAKECMDGOALS)))
 	@:
 endif
 
-.PHONY: all %.remove install uninstall config $(LIST) $(ALIAS) bin
+.PHONY: all install uninstall config $(LIST) $(ALIAS) bin

--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@ follow the KISS principle as possible as I can.
 # Minimal Requirements
 - `bash` >= 4.x
 
+# Package Install / Uninstall
+
+All packages under this dotfile repository now provide both install and uninstall entries.
+
+- Install one or more packages:
+  - `make install <pkg1> <pkg2> ...`
+- Uninstall one or more packages:
+  - `make uninstall <pkg1> <pkg2> ...`
+
+Examples:
+
+- `make install git nvim tmux`
+- `make uninstall git nvim tmux`
+
+`make uninstall` will invoke each package's own `uninstall` logic before deleting the copied config directory.
+
 # Integration
 
 ## Terminal/ Shell

--- a/apt/Makefile
+++ b/apt/Makefile
@@ -6,11 +6,11 @@ OSTYPE=$(shell uname)
 
 .ONESHELL:
 
-config.$(PKG_NAME): install.$(PKG_NAME)
+config:
 	$(H)echo "-- $(PKG_NAME): setup config --"
 	$(H)echo "APT uses system-level config under /etc/apt; keep user notes in ${CONFIG_DIR}."
 
-install.$(PKG_NAME):
+install:
 	$(H)echo "-- $(PKG_NAME): check package manager --"
 	$(H)if [[ "$(OSTYPE)" != "Linux" ]]; then
 		echo "apt is only available on Linux"
@@ -18,8 +18,9 @@ install.$(PKG_NAME):
 	fi
 	$(H)sudo apt-get update
 
-remove.$(PKG_NAME):
+uninstall:
 	$(H)echo "-- $(PKG_NAME): remove config --"
 	$(H)rm -rf "${CONFIG_DIR}"
 
-.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)
+
+.PHONY: config install uninstall

--- a/bash/Makefile
+++ b/bash/Makefile
@@ -5,7 +5,7 @@ MK_PATH    := $(abspath $(lastword $(MAKEFILE_LIST)))
 MK_DIR     := $(shell dirname $(MK_PATH))
 
 .ONESHELL:
-config.$(PKG_NAME): # Run in $(CONFIG_DIR)
+config: # Run in $(CONFIG_DIR)
 	$(H)echo "-- $(PKG_NAME): setup config --"
 	$(H)$(eval f=${HOME}/.bash_profile)
 	$(H)$(eval cmd="source ${HOME}/.bashrc")
@@ -53,11 +53,12 @@ config.$(PKG_NAME): # Run in $(CONFIG_DIR)
 
 	$(H)echo "** Please restart console to apply new bash configuration **"
 
-install.$(PKG_NAME):
+install:
 	$(H)echo "-- $(PKG_NAME): install package --"
 
-remove.$(PKG_NAME):
+uninstall:
 	$(H)echo "-- $(PKG_NAME): remove package --"
 	rm -rf $(MK_DIR)
 
-.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)
+
+.PHONY: config install uninstall

--- a/broot/Makefile
+++ b/broot/Makefile
@@ -1,0 +1,35 @@
+XDG_CONFIG_HOME ?= ${HOME}/.config
+
+PKG_NAME=broot
+CONFIG_DIR=${XDG_CONFIG_HOME}/$(PKG_NAME)
+OSTYPE=$(shell uname)
+
+.ONESHELL:
+
+config:
+	$(H)echo "-- $(PKG_NAME): setup config --"
+
+install:
+	$(H)echo "-- $(PKG_NAME): install package --"
+	$(H)if command -v broot >/dev/null 2>&1; then
+		echo "broot already installed"
+	elif [[ "$(OSTYPE)" == "Darwin" ]]; then
+		brew install broot
+	elif [[ "$(OSTYPE)" == "Linux" ]]; then
+		sudo apt-get update
+		sudo apt-get install -y broot
+	else
+		echo "Unsupported OS: $(OSTYPE)"
+	fi
+
+uninstall:
+	$(H)echo "-- $(PKG_NAME): remove package/config --"
+	$(H)if [[ "$(OSTYPE)" == "Darwin" ]]; then
+		brew uninstall broot || true
+	elif [[ "$(OSTYPE)" == "Linux" ]]; then
+		sudo apt-get remove -y broot || true
+	fi
+	$(H)rm -rf "${CONFIG_DIR}"
+
+
+.PHONY: config install uninstall

--- a/cargo/Makefile
+++ b/cargo/Makefile
@@ -6,12 +6,12 @@ OSTYPE=$(shell uname)
 
 .ONESHELL:
 
-config.$(PKG_NAME): install.$(PKG_NAME)
+config:
 	$(H)echo "-- $(PKG_NAME): setup config --"
 	$(H)mkdir -p "${HOME}/.cargo"
 	$(H)ln -snf "${CONFIG_DIR}/config.toml" "${HOME}/.cargo/config.toml"
 
-install.$(PKG_NAME):
+install:
 	$(H)echo "-- $(PKG_NAME): install rust toolchain (cargo via rustup) --"
 	$(H)if command -v cargo >/dev/null 2>&1; then
 		echo "cargo already installed"
@@ -28,9 +28,10 @@ install.$(PKG_NAME):
 		curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 	fi
 
-remove.$(PKG_NAME):
+uninstall:
 	$(H)echo "-- $(PKG_NAME): remove config --"
 	$(H)rm -f "${HOME}/.cargo/config.toml"
 	$(H)rm -rf "${CONFIG_DIR}"
 
-.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)
+
+.PHONY: config install uninstall

--- a/clangd/Makefile
+++ b/clangd/Makefile
@@ -1,0 +1,36 @@
+XDG_CONFIG_HOME ?= ${HOME}/.config
+
+PKG_NAME=clangd
+CONFIG_DIR=${XDG_CONFIG_HOME}/$(PKG_NAME)
+OSTYPE=$(shell uname)
+
+.ONESHELL:
+
+config:
+	$(H)echo "-- $(PKG_NAME): setup config --"
+	$(H)test -f "${CONFIG_DIR}/config.yaml" && echo "clangd config ready"
+
+install:
+	$(H)echo "-- $(PKG_NAME): install package --"
+	$(H)if command -v clangd >/dev/null 2>&1; then
+		echo "clangd already installed"
+	elif [[ "$(OSTYPE)" == "Darwin" ]]; then
+		brew install llvm
+	elif [[ "$(OSTYPE)" == "Linux" ]]; then
+		sudo apt-get update
+		sudo apt-get install -y clangd
+	else
+		echo "Unsupported OS: $(OSTYPE)"
+	fi
+
+uninstall:
+	$(H)echo "-- $(PKG_NAME): remove config --"
+	$(H)if [[ "$(OSTYPE)" == "Darwin" ]]; then
+		brew uninstall llvm || true
+	elif [[ "$(OSTYPE)" == "Linux" ]]; then
+		sudo apt-get remove -y clangd || true
+	fi
+	$(H)rm -rf "${CONFIG_DIR}"
+
+
+.PHONY: config install uninstall

--- a/enhancd/Makefile
+++ b/enhancd/Makefile
@@ -4,10 +4,10 @@ ENHANCD=${CONFIG_DIR}/${PKG_NAME}.git
 SHELL:=bash
 
 .ONESHELL:
-config.$(PKG_NAME): install.$(PKG_NAME)
+config:
 	$(H)echo "-- $(PKG_NAME): setup config --"
 
-install.$(PKG_NAME):
+install:
 	$(H)echo "-- $(PKG_NAME): install package --"
 	$(H)if [[ -e $(ENHANCD) ]]; then
 		git -C $(ENHANCD) pull
@@ -15,8 +15,9 @@ install.$(PKG_NAME):
 		git clone https://github.com/b4b4r07/enhancd.git $(ENHANCD)
 	fi
 
-remove.$(PKG_NAME):
+uninstall:
 	$(H)echo "-- $(PKG_NAME): remove package --"
 	$(H)rm -rf $(CONFIG_DIR)
 
-.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)
+
+.PHONY: config install uninstall

--- a/fonts/Makefile
+++ b/fonts/Makefile
@@ -10,7 +10,8 @@ EXTRACT_DIR := $(BUILD_DIR)/fonts_extract
 
 # ---- dedupe duplicate font files (by content hash) ----
 DUP_DIR := $(BUILD_DIR)/duplicate_fonts
-.PHONY: all install clean list dedupe dedupe-dry
+
+.PHONY: all install config uninstall clean list dedupe dedupe-dry
 
 all: install
 
@@ -45,6 +46,22 @@ install:
 	echo "==> Rebuilding font cache for $(DEST_DIR)"; \
 	$(CACHE_CMD) "$(DEST_DIR)"; \
 	echo "Done."
+
+config:
+	@echo "fonts config completed"
+
+uninstall:
+	@set -euo pipefail; \
+	echo "Removing managed font folders from: $(DEST_DIR)"; \
+	for z in $(ZIP_FILES); do \
+		name="$$(basename "$$z" .zip)"; \
+		rm -rf "$(DEST_DIR)/$$name"; \
+		echo "removed: $(DEST_DIR)/$$name"; \
+	done; \
+	if command -v fc-cache >/dev/null 2>&1; then \
+		$(CACHE_CMD) "$(DEST_DIR)"; \
+	fi
+
 
 list:
 	@echo "Zip files:"; \

--- a/git/Makefile
+++ b/git/Makefile
@@ -17,7 +17,7 @@ define query_saved
 endef
 
 .ONESHELL:
-config.$(PKG_NAME):
+config:
 	$(H)echo "-- $(PKG_NAME): setup config --"
 	$(H)echo "current user.name = '$(USERNAME)'"
 	$(H)echo "current user.email = '$(EMAIL)'"
@@ -31,10 +31,11 @@ config.$(PKG_NAME):
 
 	git config --global core.hooksPath $(CONFIG_DIR)/hooks
 
-install.$(PKG_NAME):
+install:
 	$(H)echo "-- $(PKG_NAME): install package --"
 
-remove.$(PKG_NAME):
+uninstall:
 	$(H)echo "-- $(PKG_NAME): remove package --"
 
-.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)
+
+.PHONY: config install uninstall

--- a/homebrew/Makefile
+++ b/homebrew/Makefile
@@ -6,13 +6,13 @@ BREW=$(shell command -v brew)
 
 .ONESHELL:
 
-config.$(PKG_NAME): install.$(PKG_NAME)
+config:
 	$(H)echo "-- $(PKG_NAME): setup config --"
 	$(H)if [[ -f "${CONFIG_DIR}/brew.env" ]]; then
 		grep -q 'homebrew/brew.env' "${HOME}/.bashrc" || echo '[[ -f "${CONFIG_DIR}/brew.env" ]] && source "${CONFIG_DIR}/brew.env"' >> "${HOME}/.bashrc"
 	fi
 
-install.$(PKG_NAME):
+install:
 	$(H)echo "-- $(PKG_NAME): install package manager --"
 	$(H)if [[ -z "$(BREW)" ]]; then
 		/bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -20,8 +20,9 @@ install.$(PKG_NAME):
 		echo "brew already installed: $(BREW)"
 	fi
 
-remove.$(PKG_NAME):
+uninstall:
 	$(H)echo "-- $(PKG_NAME): remove config --"
 	$(H)rm -rf "${CONFIG_DIR}"
 
-.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)
+
+.PHONY: config install uninstall

--- a/htop/Makefile
+++ b/htop/Makefile
@@ -1,0 +1,35 @@
+XDG_CONFIG_HOME ?= ${HOME}/.config
+
+PKG_NAME=htop
+CONFIG_DIR=${XDG_CONFIG_HOME}/$(PKG_NAME)
+OSTYPE=$(shell uname)
+
+.ONESHELL:
+
+config:
+	$(H)echo "-- $(PKG_NAME): setup config --"
+
+install:
+	$(H)echo "-- $(PKG_NAME): install package --"
+	$(H)if command -v htop >/dev/null 2>&1; then
+		echo "htop already installed"
+	elif [[ "$(OSTYPE)" == "Darwin" ]]; then
+		brew install htop
+	elif [[ "$(OSTYPE)" == "Linux" ]]; then
+		sudo apt-get update
+		sudo apt-get install -y htop
+	else
+		echo "Unsupported OS: $(OSTYPE)"
+	fi
+
+uninstall:
+	$(H)echo "-- $(PKG_NAME): remove package/config --"
+	$(H)if [[ "$(OSTYPE)" == "Darwin" ]]; then
+		brew uninstall htop || true
+	elif [[ "$(OSTYPE)" == "Linux" ]]; then
+		sudo apt-get remove -y htop || true
+	fi
+	$(H)rm -rf "${CONFIG_DIR}"
+
+
+.PHONY: config install uninstall

--- a/kitty/Makefile
+++ b/kitty/Makefile
@@ -1,0 +1,35 @@
+XDG_CONFIG_HOME ?= ${HOME}/.config
+
+PKG_NAME=kitty
+CONFIG_DIR=${XDG_CONFIG_HOME}/$(PKG_NAME)
+OSTYPE=$(shell uname)
+
+.ONESHELL:
+
+config:
+	$(H)echo "-- $(PKG_NAME): setup config --"
+
+install:
+	$(H)echo "-- $(PKG_NAME): install package --"
+	$(H)if command -v kitty >/dev/null 2>&1; then
+		echo "kitty already installed"
+	elif [[ "$(OSTYPE)" == "Darwin" ]]; then
+		brew install --cask kitty
+	elif [[ "$(OSTYPE)" == "Linux" ]]; then
+		sudo apt-get update
+		sudo apt-get install -y kitty
+	else
+		echo "Unsupported OS: $(OSTYPE)"
+	fi
+
+uninstall:
+	$(H)echo "-- $(PKG_NAME): remove package/config --"
+	$(H)if [[ "$(OSTYPE)" == "Darwin" ]]; then
+		brew uninstall --cask kitty || true
+	elif [[ "$(OSTYPE)" == "Linux" ]]; then
+		sudo apt-get remove -y kitty || true
+	fi
+	$(H)rm -rf "${CONFIG_DIR}"
+
+
+.PHONY: config install uninstall

--- a/nix/Makefile
+++ b/nix/Makefile
@@ -5,12 +5,12 @@ CONFIG_DIR=${XDG_CONFIG_HOME}/$(PKG_NAME)
 
 .ONESHELL:
 
-config.$(PKG_NAME): install.$(PKG_NAME)
+config:
 	$(H)echo "-- $(PKG_NAME): setup config --"
 	$(H)mkdir -p "${CONFIG_DIR}"
 	$(H)test -f "${CONFIG_DIR}/nix.conf" && echo "nix config ready: ${CONFIG_DIR}/nix.conf"
 
-install.$(PKG_NAME):
+install:
 	$(H)echo "-- $(PKG_NAME): install package manager --"
 	$(H)if command -v nix >/dev/null 2>&1; then
 		echo "nix already installed"
@@ -18,8 +18,9 @@ install.$(PKG_NAME):
 		curl -L https://nixos.org/nix/install | sh -s -- --daemon
 	fi
 
-remove.$(PKG_NAME):
+uninstall:
 	$(H)echo "-- $(PKG_NAME): remove config --"
 	$(H)rm -rf "${CONFIG_DIR}"
 
-.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)
+
+.PHONY: config install uninstall

--- a/npm/Makefile
+++ b/npm/Makefile
@@ -6,11 +6,11 @@ OSTYPE=$(shell uname)
 
 .ONESHELL:
 
-config.$(PKG_NAME): install.$(PKG_NAME)
+config:
 	$(H)echo "-- $(PKG_NAME): setup config --"
 	$(H)ln -snf "${CONFIG_DIR}/npmrc" "${HOME}/.npmrc"
 
-install.$(PKG_NAME):
+install:
 	$(H)echo "-- $(PKG_NAME): install package manager --"
 	$(H)if [[ "$(OSTYPE)" == "Darwin" ]]; then
 		brew install node
@@ -21,9 +21,10 @@ install.$(PKG_NAME):
 		echo "Unsupported OS: $(OSTYPE)"
 	fi
 
-remove.$(PKG_NAME):
+uninstall:
 	$(H)echo "-- $(PKG_NAME): remove config --"
 	$(H)rm -f "${HOME}/.npmrc"
 	$(H)rm -rf "${CONFIG_DIR}"
 
-.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)
+
+.PHONY: config install uninstall

--- a/nvim/Makefile
+++ b/nvim/Makefile
@@ -4,7 +4,7 @@ NVIM_VER=0.9.4
 TMP:=$(shell mktemp)
 
 .ONESHELL:
-config.$(PKG_NAME):
+config:
 	$(H)echo "-- $(PKG_NAME): setup config --"
 	# TODO: implement different fuzzy_finder
 	# PS3='select a fuzzy finder above: '
@@ -19,12 +19,13 @@ config.$(PKG_NAME):
 	$(H)nvim +"set nomodifiable nomodified" $(TMP)
 	$(H)rm -f $(TMP)
 
-install.$(PKG_NAME):
+install:
 	$(H)echo "-- $(PKG_NAME): install package --"
 	$(H)brew install neovim@${NVIM_VER}
 
-remove.$(PKG_NAME):
+uninstall:
 	$(H)echo "-- $(PKG_NAME): remove package --"
 	$(H)brew remove neovim
 
-.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)
+
+.PHONY: config install uninstall

--- a/pipx/Makefile
+++ b/pipx/Makefile
@@ -6,11 +6,11 @@ OSTYPE=$(shell uname)
 
 .ONESHELL:
 
-config.$(PKG_NAME): install.$(PKG_NAME)
+config:
 	$(H)echo "-- $(PKG_NAME): setup config --"
 	$(H)pipx ensurepath
 
-install.$(PKG_NAME):
+install:
 	$(H)echo "-- $(PKG_NAME): install package manager --"
 	$(H)if [[ "$(OSTYPE)" == "Darwin" ]]; then
 		brew install pipx
@@ -21,8 +21,9 @@ install.$(PKG_NAME):
 		echo "Unsupported OS: $(OSTYPE)"
 	fi
 
-remove.$(PKG_NAME):
+uninstall:
 	$(H)echo "-- $(PKG_NAME): remove config --"
 	$(H)rm -rf "${CONFIG_DIR}"
 
-.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)
+
+.PHONY: config install uninstall

--- a/procps/Makefile
+++ b/procps/Makefile
@@ -1,0 +1,33 @@
+XDG_CONFIG_HOME ?= ${HOME}/.config
+
+PKG_NAME=procps
+CONFIG_DIR=${XDG_CONFIG_HOME}/$(PKG_NAME)
+OSTYPE=$(shell uname)
+
+.ONESHELL:
+
+config:
+	$(H)echo "-- $(PKG_NAME): setup config --"
+
+install:
+	$(H)echo "-- $(PKG_NAME): install package --"
+	$(H)if command -v top >/dev/null 2>&1; then
+		echo "procps/top already available"
+	elif [[ "$(OSTYPE)" == "Darwin" ]]; then
+		echo "procps unavailable on macOS; skip"
+	elif [[ "$(OSTYPE)" == "Linux" ]]; then
+		sudo apt-get update
+		sudo apt-get install -y procps
+	else
+		echo "Unsupported OS: $(OSTYPE)"
+	fi
+
+uninstall:
+	$(H)echo "-- $(PKG_NAME): remove package/config --"
+	$(H)if [[ "$(OSTYPE)" == "Linux" ]]; then
+		sudo apt-get remove -y procps || true
+	fi
+	$(H)rm -rf "${CONFIG_DIR}"
+
+
+.PHONY: config install uninstall

--- a/starship/Makefile
+++ b/starship/Makefile
@@ -6,11 +6,11 @@ CMD=source $(CONFIG_DIR)/bootstrap.sh
 SHELL:=bash
 
 .ONESHELL:
-config.$(PKG_NAME): install.$(PKG_NAME)
+config:
 	$(H)echo "-- $(PKG_NAME): setup config --"
 #	echo "${BLE_CMD}" >> ${CONFIG_DIR}/bootstrap.sh
 
-install.$(PKG_NAME):
+install:
 	$(H)lib.load devel
 	$(H)if [[ -z "$(shell which ${PKG_NAME})" ]]; then
 		$(H)echo "-- $(PKG_NAME): install package --"
@@ -23,8 +23,9 @@ install.$(PKG_NAME):
 		make -C ble.sh
 	fi
 
-remove.$(PKG_NAME):
+uninstall:
 	$(H)echo "-- $(PKG_NAME): remove package --"
 	$(H)rm -rf $(CONFIG_DIR)
 
-.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)
+
+.PHONY: config install uninstall

--- a/tig/Makefile
+++ b/tig/Makefile
@@ -3,7 +3,7 @@ CONFIG_DIR=${XDG_CONFIG_HOME}/$(PKG_NAME)
 LOCAL_BIN=${HOME}/.local/bin
 
 .ONESHELL:
-config.$(PKG_NAME):
+config:
 	$(H)echo "-- $(PKG_NAME): setup config --"
 	$(H)if [[ ! -e $(LOCAL_BIN) ]]; then
 		mkdir $(LOCAL_BIN)
@@ -11,12 +11,13 @@ config.$(PKG_NAME):
 	git config --global alias.cmd '!bash -c "source $(CONFIG_DIR)/tig.bash; $$*"'
 	$(H)ln -sf $(CONFIG_DIR)/tig.run $(LOCAL_BIN)
 
-install.$(PKG_NAME):
+install:
 	$(H)echo "-- $(PKG_NAME): install package --"
 	$(H)brew install tig
 
-remove.$(PKG_NAME):
+uninstall:
 	$(H)echo "-- $(PKG_NAME): remove package --"
 	$(H)brew remove tig
 
-.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)
+
+.PHONY: config install uninstall

--- a/tio/Makefile
+++ b/tio/Makefile
@@ -1,0 +1,35 @@
+XDG_CONFIG_HOME ?= ${HOME}/.config
+
+PKG_NAME=tio
+CONFIG_DIR=${XDG_CONFIG_HOME}/$(PKG_NAME)
+OSTYPE=$(shell uname)
+
+.ONESHELL:
+
+config:
+	$(H)echo "-- $(PKG_NAME): setup config --"
+
+install:
+	$(H)echo "-- $(PKG_NAME): install package --"
+	$(H)if command -v tio >/dev/null 2>&1; then
+		echo "tio already installed"
+	elif [[ "$(OSTYPE)" == "Darwin" ]]; then
+		brew install tio
+	elif [[ "$(OSTYPE)" == "Linux" ]]; then
+		sudo apt-get update
+		sudo apt-get install -y tio
+	else
+		echo "Unsupported OS: $(OSTYPE)"
+	fi
+
+uninstall:
+	$(H)echo "-- $(PKG_NAME): remove package/config --"
+	$(H)if [[ "$(OSTYPE)" == "Darwin" ]]; then
+		brew uninstall tio || true
+	elif [[ "$(OSTYPE)" == "Linux" ]]; then
+		sudo apt-get remove -y tio || true
+	fi
+	$(H)rm -rf "${CONFIG_DIR}"
+
+
+.PHONY: config install uninstall

--- a/tmux/Makefile
+++ b/tmux/Makefile
@@ -4,14 +4,15 @@ MK_PATH    := $(abspath $(lastword $(MAKEFILE_LIST)))
 MK_DIR     := $(shell dirname $(MK_PATH))
 
 .ONESHELL:
-config.$(PKG_NAME): # Run in $(CONFIG_DIR)
+config: # Run in $(CONFIG_DIR)
 	$(H)echo "-- $(PKG_NAME): setup config --"
 	$(H)cp -v tmux.entry ~/.local/bin
 
-install.$(PKG_NAME):
+install:
 	$(H)echo "-- $(PKG_NAME): install package --"
 
-remove.$(PKG_NAME):
+uninstall:
 	$(H)echo "-- $(PKG_NAME): remove package --"
 
-.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)
+
+.PHONY: config install uninstall

--- a/yarn/Makefile
+++ b/yarn/Makefile
@@ -5,11 +5,11 @@ CONFIG_DIR=${XDG_CONFIG_HOME}/$(PKG_NAME)
 
 .ONESHELL:
 
-config.$(PKG_NAME): install.$(PKG_NAME)
+config:
 	$(H)echo "-- $(PKG_NAME): setup config --"
 	$(H)ln -snf "${CONFIG_DIR}/yarnrc.yml" "${HOME}/.yarnrc.yml"
 
-install.$(PKG_NAME):
+install:
 	$(H)echo "-- $(PKG_NAME): install package manager --"
 	$(H)if ! command -v node >/dev/null 2>&1; then
 		echo "node is required; run make npm first"
@@ -24,9 +24,10 @@ install.$(PKG_NAME):
 		corepack prepare yarn@stable --activate
 	fi
 
-remove.$(PKG_NAME):
+uninstall:
 	$(H)echo "-- $(PKG_NAME): remove config --"
 	$(H)rm -f "${HOME}/.yarnrc.yml"
 	$(H)rm -rf "${CONFIG_DIR}"
 
-.PHONY: config.$(PKG_NAME) install.$(PKG_NAME) remove.$(PKG_NAME)
+
+.PHONY: config install uninstall

--- a/zsh/Makefile
+++ b/zsh/Makefile
@@ -1,0 +1,35 @@
+XDG_CONFIG_HOME ?= ${HOME}/.config
+
+PKG_NAME=zsh
+CONFIG_DIR=${XDG_CONFIG_HOME}/$(PKG_NAME)
+OSTYPE=$(shell uname)
+
+.ONESHELL:
+
+config:
+	$(H)echo "-- $(PKG_NAME): setup config --"
+
+install:
+	$(H)echo "-- $(PKG_NAME): install shell --"
+	$(H)if command -v zsh >/dev/null 2>&1; then
+		echo "zsh already installed"
+	elif [[ "$(OSTYPE)" == "Darwin" ]]; then
+		brew install zsh
+	elif [[ "$(OSTYPE)" == "Linux" ]]; then
+		sudo apt-get update
+		sudo apt-get install -y zsh
+	else
+		echo "Unsupported OS: $(OSTYPE)"
+	fi
+
+uninstall:
+	$(H)echo "-- $(PKG_NAME): remove package/config --"
+	$(H)if [[ "$(OSTYPE)" == "Darwin" ]]; then
+		brew uninstall zsh || true
+	elif [[ "$(OSTYPE)" == "Linux" ]]; then
+		sudo apt-get remove -y zsh || true
+	fi
+	$(H)rm -rf "${CONFIG_DIR}"
+
+
+.PHONY: config install uninstall


### PR DESCRIPTION
### Motivation
- Standardize per-package lifecycle targets so the top-level `Makefile` can uniformly install, configure, and uninstall packages.
- Replace legacy `%.remove` behavior with explicit `install`/`config`/`uninstall` hooks to allow package-specific scripts and safer removal.
- Add missing package entries and document the new install/uninstall usage in `README.md`.

### Description
- Reworked the top-level `Makefile` `install`, `config`, and `uninstall` rules to iterate over requested packages and dispatch to per-package `Makefile` targets or `install.sh`/`configure.sh`/`uninstall.sh` scripts, removed the `%.remove` pattern, and updated `.PHONY` accordingly.
- Converted many package `Makefile`s to a consistent interface (`config`, `install`, `uninstall`) and added several new package Makefiles (`broot`, `clangd`, `htop`, `kitty`, `procps`, `tio`, `zsh`, etc.), plus updates to existing ones (for example `bash`, `git`, `cargo`, `fonts`, `nvim`, `npm`, `yarn`, `homebrew`, `pipx`, `starship`, `tmux`, `tig`).
- Updated `fonts/Makefile` to add `config` and `uninstall` targets and improved safety and output during install/uninstall, and added README docs describing `make install`/`make uninstall` usage and examples.

### Testing
- Performed dry-run checks with `make -n install git` and `make -n config git` to verify the top-level dispatcher prints the expected package steps and target invocations.
- Performed dry-run checks with `make -n uninstall git` and `make -n uninstall fonts` to confirm uninstall branches and removal commands are generated for both package and dotfile locations.
- No automated unit tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d17fdcf7c083299dcd870cc455d793)